### PR TITLE
Visualize training and test set

### DIFF
--- a/training_template.html
+++ b/training_template.html
@@ -1,0 +1,19 @@
+
+<link rel="stylesheet" type="text/css" href="apps/css/common.css">
+<link rel="stylesheet" type="text/css" href="apps/css/testing_interface.css">
+<style>
+    tr.spaceUnder>td {
+        padding-bottom: 15px;
+    }
+</style>
+<h1>ARC Training Data</h1>
+<table>
+    <tr>
+        <th>filename</th>
+        <th>train / test</th>
+        <th>index</th>
+        <th>input</th>
+        <th>output</th>
+    </tr>
+    __TRAINING_DATA__
+</table>

--- a/visualize_training_set.py
+++ b/visualize_training_set.py
@@ -1,0 +1,59 @@
+'''
+    read in the training data JSON files and create a single HTML file that shows the input and 
+    output grid for each training and test example.
+
+    This will give researchers a better overview of the types and complexity of the training examples
+
+    Author(s):
+        Carl Anderson (carl.anderson@weightwatchers.com)
+'''
+
+import glob
+import json
+
+filenames = [f for f in glob.glob("data/training/*.json")]
+
+with open("training_template.html", "r+") as f:
+    template = f.read()
+
+new_data = ""
+
+def generate_cell(val, x_idx, y_idx, sz):
+    return "<div class=\"cell symbol_%s\" x=\"%s\" y=\"%s\" symbol=\"%s\" style=\"height: %spx; width: %spx;\"></div>" % (val, x_idx , y_idx , val, sz, sz)
+
+def generate_grid(data):
+    s = "<div class='input_preview'>"
+    for i, row in enumerate(data):
+        s += "<div class='row'>"
+        for j, cell in enumerate(list(row)):
+            sz = str(int(100.0 / len(row)))
+            s += generate_cell(str(cell), str(i), str(j), str(sz))
+        s += "</div>"
+    s += "</div>"
+    return s
+
+def generate_rows(filename, data, type):
+    rows = ""
+    for i , example in enumerate(data):
+        row = "<tr class='spaceUnder'>"
+        row += "<td>" + filename + "</td>"
+        row += "<td>" + type + "</td>"
+        row += "<td>" + str(i) + "</td>"
+        row += "<td>" + generate_grid(example['input']) + "</td>"
+        row += "<td>" + generate_grid(example['output']) + "</td>"
+        row += "</tr>"
+        rows += row
+    return rows
+
+for filename in filenames:
+    with open(filename, "r+") as jsonFile:
+        data = json.load(jsonFile)
+        train = data["train"]
+        test = data["test"]
+        new_data += generate_rows(filename, train, "train")
+        new_data += generate_rows(filename, test, "test")
+
+template = template.replace("__TRAINING_DATA__", new_data)
+
+with open("training_data.html", "w") as f:
+    f.write(template)


### PR DESCRIPTION
Given the variety of examples, I find it helpful to create a single HTML page to visualize the complete set of training and test examples.

This PR consists of a simple python script that iterates through `data/training/*.json`, generates HTML and injects into a template. 

That is, run 

`python visualize_training_set.py`

and it uses the template `training_template.html` to generate output file `training_data.html`

<img width="828" alt="Screen Shot 2019-11-17 at 4 16 39 PM" src="https://user-images.githubusercontent.com/1386343/69014185-a860ae80-0955-11ea-9fa4-98f09b4e8d4e.png">


