### PR TITLE
Prevent infinite loop in floodfill corner case

### DIFF
--- a/apps/js/common.js
+++ b/apps/js/common.js
@@ -23,6 +23,10 @@ function floodfillFromLocation(grid, i, j, symbol) {
     symbol = parseInt(symbol);
 
     target = grid[i][j];
+    
+    if (target == symbol) {
+        return;
+    }
 
     function flow(i, j, symbol, target) {
         if (i >= 0 && i < grid.length && j >= 0 && j < grid[i].length) {


### PR DESCRIPTION
Prevent infinite loop that results if user tries to redundantly floodfill a section of the grid with the section's existing color.