### PR TITLE
Make sure symbol_0 is selected by default

### DIFF
--- a/apps/testing_interface.html
+++ b/apps/testing_interface.html
@@ -100,7 +100,7 @@
                         </div>
 
                         <div id="symbol_picker">
-                            <div class="symbol_preview symbol_0 selected" symbol="0"></div>
+                            <div class="symbol_preview symbol_0 selected-symbol-preview" symbol="0"></div>
                             <div class="symbol_preview symbol_1" symbol="1"></div>
                             <div class="symbol_preview symbol_2" symbol="2"></div>
                             <div class="symbol_preview symbol_3" symbol="3"></div>


### PR DESCRIPTION
Change the initial class for symbol_0 (black) from "selected" to "selected-symbol-preview" so it's selected by default. Without this change there's a subtle bug where the user can appear to be making edits that aren't actually reflected in the underlying grid. 

Consider input 7f4411d.json. If the user copies the input grid and then starts clicking on the extra cells without selecting a color, the cells will change to black. When the user submits a grid that appears to be correct, they will be told their answer is incorrect because the changes weren't reflected in the underlying grid.