### PR TITLE
Trigger resizeOutputGrid on enter

### DIFF
--- a/apps/js/testing_interface.js
+++ b/apps/js/testing_interface.js
@@ -304,6 +304,12 @@ $(document).ready(function () {
     $('input[type=radio][name=tool_switching]').change(function() {
         initializeSelectable();
     });
+    
+    $('input[type=text][name=size]').on('keydown', function(event) {
+        if (event.keyCode == 13) {
+            resizeOutputGrid();
+        }
+    });
 
     $('body').keydown(function(event) {
         // Copy and paste functionality.


### PR DESCRIPTION
Very simply allow the user to hit enter to resize the output grid instead of clicking on the Resize button.